### PR TITLE
This PR introduces a new loaded keyspace event

### DIFF
--- a/runtest-moduleapi
+++ b/runtest-moduleapi
@@ -25,4 +25,5 @@ $TCLSH tests/test_helper.tcl \
 --single unit/moduleapi/scan \
 --single unit/moduleapi/datatype \
 --single unit/moduleapi/auth \
+--single unit/moduleapi/keyspace_events \
 "${@}"

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2271,7 +2271,7 @@ int rdbLoadRio(rio *rdb, int rdbflags, rdbSaveInfo *rsi) {
             sdsfree(key);
             decrRefCount(val);
         } else {
-            robj keyobj;
+            robj* keyobj = createRawStringObject(sdsdup(key), sdslen(key));
 
             /* Add the new object in the hash table */
             int added = dbAddRDBLoad(db,key,val);
@@ -2280,8 +2280,7 @@ int rdbLoadRio(rio *rdb, int rdbflags, rdbSaveInfo *rsi) {
                     /* This flag is useful for DEBUG RELOAD special modes.
                      * When it's set we allow new keys to replace the current
                      * keys with the same name. */
-                    initStaticStringObject(keyobj,key);
-                    dbSyncDelete(db,&keyobj);
+                    dbSyncDelete(db,keyobj);
                     dbAddRDBLoad(db,key,val);
                 } else {
                     serverLog(LL_WARNING,
@@ -2292,12 +2291,16 @@ int rdbLoadRio(rio *rdb, int rdbflags, rdbSaveInfo *rsi) {
 
             /* Set the expire time if needed */
             if (expiretime != -1) {
-                initStaticStringObject(keyobj,key);
-                setExpire(NULL,db,&keyobj,expiretime);
+                setExpire(NULL,db,keyobj,expiretime);
             }
 
             /* Set usage information (for eviction). */
             objectSetLRUOrLFU(val,lfu_freq,lru_idle,lru_clock,1000);
+
+            // call key space notification key loaded
+            notifyKeyspaceEvent(NOTIFY_GENERIC, "loaded", keyobj, db->id);
+
+            decrRefCount(keyobj);
         }
 
         /* Loading the database more slowly is useful in order to test

--- a/tests/modules/Makefile
+++ b/tests/modules/Makefile
@@ -4,7 +4,7 @@ uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
 
 # Compile flags for linux / osx
 ifeq ($(uname_S),Linux)
-	SHOBJ_CFLAGS ?= -W -Wall -fno-common -g -ggdb -std=c99 -O2
+	SHOBJ_CFLAGS ?= -W -Wall -fno-common -g -ggdb -std=c99 -O0 -DREDISMODULE_EXPERIMENTAL_API
 	SHOBJ_LDFLAGS ?= -shared
 else
 	SHOBJ_CFLAGS ?= -W -Wall -dynamic -fno-common -g -ggdb -std=c99 -O2
@@ -22,7 +22,8 @@ TEST_MODULES = \
     blockonkeys.so \
     scan.so \
     datatype.so \
-    auth.so
+    auth.so \
+    keyspace_events.so
 
 .PHONY: all
 

--- a/tests/modules/keyspace_events.c
+++ b/tests/modules/keyspace_events.c
@@ -1,0 +1,90 @@
+/* This module is used to test the server keyspace events API.
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * Copyright (c) 2019, Salvatore Sanfilippo <antirez at gmail dot com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of Redis nor the names of its contributors may be used
+ *     to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "redismodule.h"
+#include <stdio.h>
+#include <string.h>
+
+/** strores all the keys on which we got 'loaded' keyspace notification **/
+RedisModuleDict *loaded_event_log = NULL;
+
+static int KeySpace_Notification(RedisModuleCtx *ctx, int type, const char *event, RedisModuleString *key){
+    REDISMODULE_NOT_USED(ctx);
+    REDISMODULE_NOT_USED(type);
+
+    if(strcmp(event, "loaded") == 0){
+        const char* keyName = RedisModule_StringPtrLen(key, NULL);
+        int nokey;
+        RedisModule_DictGetC(loaded_event_log, (void*)keyName, strlen(keyName), &nokey);
+        if(nokey){
+            RedisModule_DictSetC(loaded_event_log, (void*)keyName, strlen(keyName), NULL);
+        }
+    }
+
+    return REDISMODULE_OK;
+}
+
+static int cmdLoadedEvents(RedisModuleCtx *ctx, RedisModuleString **argv, int argc){
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
+
+    long long size = RedisModule_DictSize(loaded_event_log);
+    RedisModule_ReplyWithLongLong(ctx, size);
+    return REDISMODULE_OK;
+}
+
+/* This function must be present on each Redis module. It is used in order to
+ * register the commands into the Redis server. */
+int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
+
+    if (RedisModule_Init(ctx,"testkeyspace",1,REDISMODULE_APIVER_1) == REDISMODULE_ERR) return REDISMODULE_ERR;
+
+    loaded_event_log = RedisModule_CreateDict(ctx);
+
+    if(RedisModule_SubscribeToKeyspaceEvents(ctx, REDISMODULE_NOTIFY_ALL, KeySpace_Notification) != REDISMODULE_OK){
+        return REDISMODULE_ERR;
+    }
+
+    if (RedisModule_CreateCommand(ctx,"keyspace.loaded_events", cmdLoadedEvents,"",0,0,0) == REDISMODULE_ERR){
+        return REDISMODULE_ERR;
+    }
+
+    return REDISMODULE_OK;
+}
+
+int RedisModule_OnUnload(RedisModuleCtx *ctx) {
+    RedisModule_FreeDict(ctx, loaded_event_log);
+    loaded_event_log = NULL;
+    return REDISMODULE_OK;
+}

--- a/tests/unit/moduleapi/keyspace_events.tcl
+++ b/tests/unit/moduleapi/keyspace_events.tcl
@@ -1,0 +1,17 @@
+set testmodule [file normalize tests/modules/keyspace_events.so]
+
+tags "modules" {
+    start_server [list overrides [list loadmodule "$testmodule"]] {
+
+        test {Test loaded key space event} {
+            r set x 1
+            r hset y f v
+            r lpush z 1 2 3
+            r sadd p 1 2 3
+            r zadd t 1 f1 2 f2
+            r xadd s * f v
+            r debug reload
+            assert_equal 6 [r keyspace.loaded_events]
+        }
+	}
+}


### PR DESCRIPTION
The new event will be fired after a key was loaded from RDB and added to the keyspace.
The new event will be triggered to modules which registered to REDISMODULE_NOTIFY_GENERIC event type.

This PR also introduce tests for the new notification inside a new test file called: keyspace_events.c

notice that basically there are no tests for keyspace notification API so I thought it makes sense to add a new test file for this and add the future keyspace notification tests in this file.